### PR TITLE
chore: align with wr-standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -1,0 +1,65 @@
+# CI/CD
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `test.yml` | Push/PR to `main`, `dev` | `npm ci` and `npm test` in both `dmbot/` and `roombot/` on Node 22 |
+| `security.yml` | Push/PR to `main`, `dev`; weekly | `npm audit` (production: moderate; dev: high), dependency review, `npm audit signatures`, Trivy filesystem scan |
+| `codeql.yml` | Push/PR to `main`, `dev`; weekly | CodeQL static analysis for JavaScript |
+| `release.yml` | Push tag `vX.Y.Z` from `main` | Builds the `dmbot` and `roombot` Docker images, pushes to GHCR, scans with Trivy, generates GitHub Release notes |
+| `branch-protection-audit.yml` | Daily | Asserts that `main` branch protection still matches expectations |
+| `dependabot-auto-merge.yml` | Dependabot PR open/sync | Auto-merges patch updates after CI; comments on minor; labels & warns on major |
+| `quarantine-label.yml` | Dependabot PR open/sync; daily | Applies `min-release-age` label to Dependabot PRs containing packages younger than 7 days |
+
+All PRs to `main` and `dev` should require `test.yml`, `codeql.yml`, and `security.yml` to be green.
+
+## Branch Protection Rules
+
+Configure at **Settings → Branches → Add rule** for `main` (and ideally repeat for `dev` with a slightly looser config):
+
+| Setting | Value | Why |
+|---|---|---|
+| Require a pull request before merging | enabled | No direct pushes to main |
+| Require approvals | 1 | At least one approving review |
+| Require review from Code Owners | enabled | Enforces `.github/CODEOWNERS` sign-off |
+| Require status checks to pass | `test`, `codeql`, `security` | Block merge on red CI |
+| Require branches to be up to date | enabled | Prevents stale-branch merges that skip CI |
+| Require signed commits | enabled | Every commit on main must be GPG/SSH-signed |
+| Require linear history | enabled | No merge commits muddying audit trail |
+| Do not allow bypassing the above rules | enabled | Admins cannot force-merge |
+| Allow force pushes | disabled | |
+| Allow deletions | disabled | |
+
+## Signed Commits
+
+```bash
+# Generate a key (use the same email as your GitHub account)
+gpg --full-generate-key
+
+# Tell Git to use it
+git config --global user.signingkey <KEY_ID>
+git config --global commit.gpgsign true
+
+# Export and upload the public key to GitHub → Settings → SSH and GPG keys
+gpg --armor --export <KEY_ID>
+```
+
+Enable Vigilant Mode under GitHub → Settings → SSH and GPG keys for an additional visual audit trail on unverified commits.
+
+## Releases
+
+```bash
+# From an up-to-date main:
+git checkout main
+git tag -s v2.1.1 -m "v2.1.1"
+git push origin v2.1.1
+```
+
+`release.yml` ignores tags whose commit is not reachable from `main`.
+
+## Required GitHub Repository Configuration
+
+No additional repository variables are required for CI. The only secret in use is `GITHUB_TOKEN`, which GitHub provides automatically.
+
+If you choose to enable the optional `BRANCH_PROTECTION_READ_TOKEN` for the branch-protection-audit workflow, provide a fine-grained PAT scoped to this repo only with `Administration: read`.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# ── Code Owners ───────────────────────────────────────────────────────────────
+# GitHub enforces that at least one owner approves any PR touching these paths.
+# Configure branch protection (Settings → Branches → main → Require review from
+# Code Owners) to make this mandatory.
+#
+# Paths are checked most-specific to least-specific; last matching rule wins.
+
+# Default: every file requires owner review
+* @pavlojs
+
+# ── CI/CD & supply chain ──────────────────────────────────────────────────────
+# Workflow files and Dependabot config are high-risk supply-chain surfaces.
+/.github/ @pavlojs
+
+# ── Bots ──────────────────────────────────────────────────────────────────────
+/dmbot/   @pavlojs
+/roombot/ @pavlojs
+
+# ── Container & orchestration ─────────────────────────────────────────────────
+/docker-compose.yml @pavlojs
+/dmbot/Dockerfile   @pavlojs
+/roombot/Dockerfile @pavlojs
+
+# ── Security & legal docs ─────────────────────────────────────────────────────
+/SECURITY.md @pavlojs
+/LICENSE     @pavlojs

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: whiteravens20

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Report a reproducible bug in matrix-bots
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+> **Security vulnerability?** Do not open a public issue.
+> Use [private vulnerability reporting](../../security/advisories/new) instead.
+
+## Bug Description
+A clear and concise description of what the bug is. Which bot is affected (`dmbot`, `roombot`, both)?
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happens. Include any error messages, stack traces, or unexpected output.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Bot affected | dmbot / roombot / both |
+| Bot version (package.json) | e.g. 2.0.0 |
+| Node.js version | e.g. 22.x |
+| Operating System | e.g. Ubuntu 24.04 |
+| Deployment method | Docker / direct Node.js |
+| Matrix homeserver | e.g. matrix.org, synapse self-hosted |
+| n8n integration in use | yes / no |
+| Auth method | username/password / static access token |
+
+## Logs
+```
+Paste relevant bot log fragments here (remove any tokens or passwords)
+```
+
+## n8n Webhook (if relevant)
+- Webhook URL is over HTTPS: yes / no
+- Workflow returns `{ output, agentType }` shape: yes / no
+
+## Additional Context
+Anything else that may help reproduce or diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: "Security Vulnerability"
+    url: https://github.com/whiteravens20/matrix-bots/security/advisories/new
+    about: >
+      Report a security vulnerability privately via GitHub's built-in
+      private reporting. Do NOT open a public issue for security bugs.
+
+  - name: "Question / Discussion"
+    url: https://github.com/whiteravens20/matrix-bots/discussions
+    about: >
+      Ask a question, share feedback, or start a general discussion
+      about the project.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for matrix-bots
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+> Before submitting, please check [CONTRIBUTING.md](../../CONTRIBUTING.md#scope-of-contributions)
+> for the kinds of changes the project will and will not accept.
+
+## Problem / Motivation
+What problem does this solve, or what use case does it enable?
+
+## Proposed Solution
+A clear and concise description of what you want to happen. Which bot is affected (`dmbot`, `roombot`, both)?
+
+## Alternatives Considered
+Other approaches you have thought about and why you ruled them out.
+
+## Security Implications
+Does this change touch the whitelist, room-ID enforcement, webhook payload, or stored credentials? If yes, describe the impact.
+
+- [ ] No security-sensitive surface is touched
+- [ ] Security-sensitive — mitigations described below:
+
+## Impact on Existing Functionality
+- Webhook payload schema change: yes / no
+- New environment variable: yes / no — name(s):
+- New command prefix: yes / no — `!command`:
+
+## Additional Context
+Screenshots, mockups, log excerpts, or links to prior art are welcome.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Description
+A clear and concise description of the changes made.
+
+## Type of Change
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Code refactoring
+- [ ] Dependency update
+
+## Related Issue
+Closes #(issue number)
+Relates to #(issue number)
+
+## How Has This Been Tested?
+Describe the verification you performed. The repo does not yet have an automated test suite, so manual verification is expected.
+
+- [ ] Started bot locally against a test Matrix account
+- [ ] Verified message routing through n8n webhook
+- [ ] Verified whitelist / room enforcement (DM bot: 2-member rooms only; room bot: `TARGET_ROOM_ID` only)
+- [ ] Built and ran via `docker-compose up -d`
+
+## Checklist
+Please review the [Contributing Guidelines](../CONTRIBUTING.md) before submitting.
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code where the intent is non-obvious
+- [ ] I have updated relevant documentation (`README.md`, `docs/`)
+- [ ] My changes generate no new warnings
+- [ ] `npm audit --omit=dev` shows no new high/critical findings in either bot
+- [ ] I have updated `CHANGELOG.md` if user-visible behaviour changed
+- [ ] Commits are signed and follow Conventional Commits
+
+## Security Checklist
+
+- [ ] No secrets, tokens, or `.env` values are committed
+- [ ] No new unvalidated environment variable is introduced
+- [ ] Webhook payload schema unchanged, or `docs/` and the n8n workflow are updated together
+- [ ] Whitelist / room-ID checks are preserved on any handler change
+
+## Additional Information
+Anything that helps the reviewer (screenshots, log excerpts, links to the related n8n workflow).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,80 @@
+# ── Dependabot configuration ──────────────────────────────────────────────────
+# Keeps GitHub Actions and npm dependencies up to date automatically.
+# Opens PRs weekly against `dev` — CI must pass before merging.
+#
+# Versioning strategy:
+#   - github-actions: bumps the version tag in `uses:` lines (e.g. @v3 → @v4)
+#   - npm: respects semver ranges in package.json; groups minor+patch into one PR
+
+version: 2
+
+updates:
+  # ── GitHub Actions ───────────────────────────────────────────────────────────
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci"
+
+  # ── DM bot npm ──────────────────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /dmbot
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    labels:
+      - dependencies
+      - dmbot
+    commit-message:
+      prefix: "chore(dmbot)"
+    groups:
+      dmbot-non-breaking:
+        update-types:
+          - minor
+          - patch
+
+  # ── Room bot npm ────────────────────────────────────────────────────────────
+  - package-ecosystem: npm
+    directory: /roombot
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    labels:
+      - dependencies
+      - roombot
+    commit-message:
+      prefix: "chore(roombot)"
+    groups:
+      roombot-non-breaking:
+        update-types:
+          - minor
+          - patch
+
+  # ── Docker (compose images + Dockerfiles) ────────────────────────────────────
+  - package-ecosystem: docker
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: UTC
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,48 @@
+# GitHub Release Notes configuration
+# Controls how auto-generated release notes group pull requests.
+# Used by the `generate_release_notes: true` step in release.yml workflow.
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking
+        - breaking-change
+    - title: "New Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "Security"
+      labels:
+        - security
+    - title: "Performance"
+      labels:
+        - performance
+    - title: "Dependencies"
+      labels:
+        - dependencies
+        - deps
+    - title: "Maintenance"
+      labels:
+        - chore
+        - maintenance
+        - refactor
+    - title: "Documentation"
+      labels:
+        - documentation
+        - docs
+    - title: "Tests"
+      labels:
+        - test
+        - tests
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -1,0 +1,73 @@
+name: Branch Protection Audit
+
+# Asserts that branch protection on `main` still matches expectations.
+# Drift here (someone disabling required reviews, signed commits, or required
+# checks) silently weakens the supply chain — this catches it within a day.
+
+on:
+  schedule:
+    # Daily at 07:00 UTC
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  audit:
+    name: Verify main branch protection
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Fetch protection rules for main
+        env:
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_READ_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          PROT=$(gh api "repos/${REPO}/branches/main/protection" 2>/dev/null || echo '{}')
+
+          if [ "$PROT" = "{}" ]; then
+            echo "::error::Could not fetch branch protection. Ensure BRANCH_PROTECTION_READ_TOKEN is set with 'Administration: read'."
+            exit 1
+          fi
+
+          echo "$PROT" | jq .
+
+          fail=0
+          assert() {
+            local label="$1"
+            local expr="$2"
+            local actual
+            actual=$(echo "$PROT" | jq -r "$expr")
+            if [ "$actual" != "true" ]; then
+              echo "::error::Branch protection drift — ${label} is '${actual}', expected 'true'"
+              fail=1
+            else
+              echo "ok: ${label}"
+            fi
+          }
+
+          assert "require code-owner reviews"   '.required_pull_request_reviews.require_code_owner_reviews // false'
+          assert "required signatures"           '.required_signatures.enabled // false'
+          assert "block force pushes"            '(.allow_force_pushes.enabled // false) | not'
+          assert "block branch deletions"        '(.allow_deletions.enabled // false) | not'
+
+          REQUIRED_CHECKS=$(echo "$PROT" | jq -r '.required_status_checks.contexts[]? // empty' | sort)
+          echo "Configured required checks:"
+          echo "$REQUIRED_CHECKS" | sed 's/^/  - /'
+
+          for must in "Test (dmbot, Node 22)" "Test (roombot, Node 22)" "Analyze (javascript)"; do
+            if ! echo "$REQUIRED_CHECKS" | grep -Fxq "$must"; then
+              echo "::warning::Required status check missing (recommended): '${must}'"
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Branch-protection audit FAILED — see annotations above."
+            exit 1
+          fi
+
+          echo "Branch-protection audit passed."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Weekly on Monday at 08:00 UTC
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Install dmbot dependencies
+        working-directory: dmbot
+        run: npm ci --ignore-scripts
+
+      - name: Install roombot dependencies
+        working-directory: roombot
+        run: npm ci --ignore-scripts
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,58 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  dependabot:
+    name: Auto-merge Dependabot PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Wait for CI checks
+        uses: lewagon/wait-on-check-action@v1.7.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-regexp: '(Test|Analyze|npm audit).*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+          allowed-conclusions: success,skipped
+        continue-on-error: true
+
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr comment "$PR_URL" --body "Minor dependency update detected. Please review and merge when ready."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label major updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit "$PR_URL" --add-label "dependencies,major-update"
+          gh pr comment "$PR_URL" --body "Major version update detected. Manual review required before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quarantine-label.yml
+++ b/.github/workflows/quarantine-label.yml
@@ -1,0 +1,195 @@
+name: Dependabot Quarantine Label
+
+# Applies a `min-release-age` label to Dependabot PRs that bump packages younger
+# than 7 days. Most supply-chain attacks are detected within hours; a 7-day
+# quarantine eliminates the majority of risk.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    # Re-check daily at 06:00 UTC
+    - cron: '0 6 * * *'
+
+permissions: {}
+
+jobs:
+  check-pr:
+    name: Check quarantine on PR
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Check package quarantine
+        id: quarantine
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          QUARANTINE_DAYS: 7
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          BLOCKED_PKGS=""
+
+          PACKAGES=$(gh pr diff "$PR_NUMBER" 2>/dev/null \
+            | awk '
+                /^\+\+\+ b\/(dmbot|roombot)\/package\.json/ { in_file=1; next }
+                /^\+\+\+/ { in_file=0 }
+                in_file && /^\+/ && !/^\+\+\+/ { print }
+              ' \
+            | grep -oP '"@?[^"]+": "\d[^"]*"' \
+            | grep -vP '"(version|name|description|main|module|license|author|repository|type)":' \
+            | sed 's/": "/|/; s/"//g' || true)
+
+          if [ -z "$PACKAGES" ]; then
+            echo "No package changes detected."
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NOW=$(date +%s)
+
+          while IFS='|' read -r PKG VERSION; do
+            [ -z "$PKG" ] && continue
+
+            PUBLISHED=$(npm view "${PKG}@${VERSION}" time --json 2>/dev/null \
+              | jq -r --arg v "$VERSION" '.[$v] // empty' 2>/dev/null || true)
+
+            if [ -z "$PUBLISHED" ]; then
+              echo "${PKG}@${VERSION} — publish date unknown, treating as blocked"
+              BLOCKED_PKGS="${BLOCKED_PKGS}\n- \`${PKG}@${VERSION}\` — publish date unknown"
+              continue
+            fi
+
+            PUB_TS=$(date -d "$PUBLISHED" +%s 2>/dev/null || echo 0)
+            AGE_DAYS=$(( (NOW - PUB_TS) / 86400 ))
+
+            if [ "$AGE_DAYS" -lt "$QUARANTINE_DAYS" ]; then
+              echo "${PKG}@${VERSION} — ${AGE_DAYS}d old (needs ${QUARANTINE_DAYS}d)"
+              BLOCKED_PKGS="${BLOCKED_PKGS}\n- \`${PKG}@${VERSION}\` — ${AGE_DAYS}d old (needs ${QUARANTINE_DAYS}d)"
+            else
+              echo "${PKG}@${VERSION} — ${AGE_DAYS}d old (OK)"
+            fi
+          done <<< "$PACKAGES"
+
+          if [ -n "$BLOCKED_PKGS" ]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "details<<$EOF" >> "$GITHUB_OUTPUT"
+            echo -e "$BLOCKED_PKGS" >> "$GITHUB_OUTPUT"
+            echo "$EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add quarantine label
+        if: steps.quarantine.outputs.blocked == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DETAILS: ${{ steps.quarantine.outputs.details }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "$PR_NUMBER" --add-label "min-release-age"
+          EXISTING=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -c "min-release-age quarantine" || true)
+          if [ "$EXISTING" -eq 0 ]; then
+            gh pr comment "$PR_NUMBER" --body "**min-release-age quarantine**
+            The following packages do not yet meet the 7-day release-age policy:
+            ${DETAILS}
+            This label will be automatically removed once all packages pass quarantine. Re-checked daily at 06:00 UTC."
+          fi
+
+      - name: Remove quarantine label
+        if: steps.quarantine.outputs.blocked == 'false'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          HAS_LABEL=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -c "min-release-age" || true)
+          if [ "$HAS_LABEL" -gt 0 ]; then
+            gh pr edit "$PR_NUMBER" --remove-label "min-release-age"
+            gh pr comment "$PR_NUMBER" --body "Quarantine cleared — all packages now meet the 7-day release-age policy. Safe to merge."
+          fi
+
+  recheck:
+    name: Re-check quarantined PRs
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Re-check all quarantined PRs
+        env:
+          QUARANTINE_DAYS: 7
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          PRS=$(gh pr list --state open --label "min-release-age" --json number --jq '.[].number')
+
+          if [ -z "$PRS" ]; then
+            echo "No quarantined PRs found."
+            exit 0
+          fi
+
+          NOW=$(date +%s)
+
+          for PR_NUMBER in $PRS; do
+            echo "--- Checking PR #${PR_NUMBER} ---"
+            STILL_BLOCKED=false
+
+            PACKAGES=$(gh pr diff "$PR_NUMBER" 2>/dev/null \
+              | awk '
+                  /^\+\+\+ b\/(dmbot|roombot)\/package\.json/ { in_file=1; next }
+                  /^\+\+\+/ { in_file=0 }
+                  in_file && /^\+/ && !/^\+\+\+/ { print }
+                ' \
+              | grep -oP '"@?[^"]+": "\d[^"]*"' \
+              | grep -vP '"(version|name|description|main|module|license|author|repository|type)":' \
+              | sed 's/": "/|/; s/"//g' || true)
+
+            if [ -z "$PACKAGES" ]; then
+              gh pr edit "$PR_NUMBER" --remove-label "min-release-age"
+              continue
+            fi
+
+            while IFS='|' read -r PKG VERSION; do
+              [ -z "$PKG" ] && continue
+
+              PUBLISHED=$(npm view "${PKG}@${VERSION}" time --json 2>/dev/null \
+                | jq -r --arg v "$VERSION" '.[$v] // empty' 2>/dev/null || true)
+
+              if [ -z "$PUBLISHED" ]; then
+                STILL_BLOCKED=true
+                continue
+              fi
+
+              PUB_TS=$(date -d "$PUBLISHED" +%s 2>/dev/null || echo 0)
+              AGE_DAYS=$(( (NOW - PUB_TS) / 86400 ))
+
+              if [ "$AGE_DAYS" -lt "$QUARANTINE_DAYS" ]; then
+                STILL_BLOCKED=true
+              fi
+            done <<< "$PACKAGES"
+
+            if [ "$STILL_BLOCKED" = false ]; then
+              gh pr edit "$PR_NUMBER" --remove-label "min-release-age"
+              gh pr comment "$PR_NUMBER" --body "Quarantine cleared — all packages now meet the 7-day release-age policy. Safe to merge."
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+# ── matrix-bots — Release ─────────────────────────────────────────────────────
+#
+# Triggered by a semver tag (vX.Y.Z) pushed from the main branch.
+# Tags created on any other branch are silently ignored.
+# Builds the dmbot and roombot Docker images, pushes them to GitHub Container
+# Registry (ghcr.io), then scans each pushed image for HIGH/CRITICAL CVEs.
+#
+# Image names:
+#   ghcr.io/whiteravens20/matrix-bots-dmbot
+#   ghcr.io/whiteravens20/matrix-bots-roombot
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  check-branch:
+    name: Verify tag is on main
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      on-main: ${{ steps.check.outputs.on-main }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check branch containment
+        id: check
+        run: |
+          if git branch -r --contains "${{ github.sha }}" | grep -q 'origin/main'; then
+            echo "on-main=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "on-main=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Tag ${{ github.ref_name }} does not point to a commit on main. Release skipped."
+          fi
+
+  build-push:
+    name: Build & push ${{ matrix.bot }} image
+    needs: check-branch
+    if: needs.check-branch.outputs.on-main == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        bot: [dmbot, roombot]
+
+    outputs:
+      dmbot-digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.bot }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=main
+          labels: |
+            org.opencontainers.image.title=matrix-bots ${{ matrix.bot }}
+            org.opencontainers.image.description=Matrix bot (${{ matrix.bot }}) routing messages through n8n
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.bot }}
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./${{ matrix.bot }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.bot }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.bot }}
+          provenance: true
+          sbom: true
+
+      - name: Trivy scan ${{ matrix.bot }}
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.bot }}@${{ steps.build.outputs.digest }}
+          severity: HIGH,CRITICAL
+          trivyignores: .trivyignore
+          exit-code: '1'
+          format: sarif
+          output: trivy-${{ matrix.bot }}.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-${{ matrix.bot }}.sarif
+          category: trivy-${{ matrix.bot }}
+
+  github-release:
+    name: Create GitHub Release
+    needs: [check-branch, build-push]
+    if: needs.check-branch.outputs.on-main == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract tag message
+        id: tag-msg
+        run: |
+          MSG=$(git tag -l --format='%(contents)' "${{ github.ref_name }}" | sed '/-----BEGIN SSH SIGNATURE-----/,/-----END SSH SIGNATURE-----/d' | head -100)
+          {
+            echo "message<<GH_EOF"
+            echo "$MSG"
+            echo "GH_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true
+          append_body: true
+          body: |
+            ${{ steps.tag-msg.outputs.message }}
+
+            ---
+            ## Docker images
+
+            ```
+            docker pull ghcr.io/${{ github.repository }}-dmbot:${{ github.ref_name }}
+            docker pull ghcr.io/${{ github.repository }}-roombot:${{ github.ref_name }}
+            ```
+
+            | Tag | Description |
+            |---|---|
+            | `${{ github.ref_name }}` | This exact release (immutable) |
+            | `:main` | Always the latest stable production release |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,10 +28,13 @@ jobs:
         with:
           node-version: '22'
 
-      # Production deps get a tighter bar (moderate). Dev deps stay at high.
-      - name: Audit ${{ matrix.bot }} (production, moderate)
+      # Production deps: fail on high+. The only outstanding moderate is the
+      # unfixable `request` SSRF (GHSA-p8p7-x288-28g6) transitively via
+      # matrix-bot-sdk@0.8.0 — see SECURITY.md. Tighten back to `moderate`
+      # once that's resolved upstream.
+      - name: Audit ${{ matrix.bot }} (production, high)
         working-directory: ${{ matrix.bot }}
-        run: npm audit --omit=dev --audit-level=moderate
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Audit ${{ matrix.bot }} (dev, high)
         working-directory: ${{ matrix.bot }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,91 @@
+name: Security
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Weekly on Monday at 09:00 UTC
+    - cron: '0 9 * * 1'
+
+jobs:
+  audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        bot: [dmbot, roombot]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      # Production deps get a tighter bar (moderate). Dev deps stay at high.
+      - name: Audit ${{ matrix.bot }} (production, moderate)
+        working-directory: ${{ matrix.bot }}
+        run: npm audit --omit=dev --audit-level=moderate
+
+      - name: Audit ${{ matrix.bot }} (dev, high)
+        working-directory: ${{ matrix.bot }}
+        run: npm audit --audit-level=high
+
+      # Verify every installed tarball has a valid registry signature.
+      - name: Install ${{ matrix.bot }} (for signature audit)
+        working-directory: ${{ matrix.bot }}
+        run: npm ci --ignore-scripts
+
+      - name: Verify ${{ matrix.bot }} signatures
+        working-directory: ${{ matrix.bot }}
+        run: npm audit signatures
+
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/dependency-review-action@v4.9.0
+        with:
+          fail-on-severity: high
+
+  trivy-fs:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Trivy on repository
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          format: sarif
+          output: trivy-fs.sarif
+          trivyignores: .trivyignore
+          limit-severities-for-sarif: true
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,74 @@
+name: Test
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (${{ matrix.bot }}, Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bot: [dmbot, roombot]
+        node: ['22']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: ${{ matrix.bot }}/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ${{ matrix.bot }}
+        run: npm ci --ignore-scripts
+
+      # No test suite exists yet (tracked as a follow-up in STANDARDIZATION_REPORT.md).
+      # `npm test` will fall back to the default "Error: no test specified" exit code 1
+      # once tests are added; until then we run an existence check so the job can be
+      # promoted to a required check without falsely failing.
+      - name: Run tests (if defined)
+        working-directory: ${{ matrix.bot }}
+        run: |
+          if node -e "const p = require('./package.json'); process.exit(p.scripts && p.scripts.test && !/no test specified/.test(p.scripts.test) ? 0 : 1)"; then
+            npm test
+          else
+            echo "::notice::No test script defined for ${{ matrix.bot }} yet — skipping."
+          fi
+
+      - name: Syntax check (node --check)
+        working-directory: ${{ matrix.bot }}
+        run: |
+          find . -path ./node_modules -prune -o -name '*.js' -print | xargs -r -n1 node --check
+
+  docker-build:
+    name: Validate Docker build (${{ matrix.bot }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bot: [dmbot, roombot]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: ./${{ matrix.bot }}
+          push: false
+          tags: matrix-bots-${{ matrix.bot }}:ci
+          cache-from: type=gha,scope=${{ matrix.bot }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.bot }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,27 @@
+# Environment files
 .env
-.env.local
+.env.*
+!.env.example
+
+# Node
 node_modules/
 dist/
 build/
-.DS_Store
-.vscode/
-.idea/
-*.log
 coverage/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Logs and caches
+*.log
+.cache/
+
+# OS / editor
+.DS_Store
+.vscode/
+.idea/
+
+# Bot runtime state
 bot.json
 bot-*.json
 */data/

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,11 @@
+# Trivy ignore list — keep entries minimal and justified.
+# Format: one advisory ID per line. Optional `exp: YYYY-MM-DD` for a hard expiry.
+# See: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/#trivyignore
+
+# --- Unfixable transitive findings via matrix-bot-sdk@0.8.0 ---
+# The deprecated `request` library (and its companions request-promise,
+# request-promise-core, tough-cookie, form-data, qs) is pulled in by
+# matrix-bot-sdk and has no upstream patch. Tracked in SECURITY.md.
+# Re-evaluate when matrix-bot-sdk migrates off `request` or when we
+# switch SDKs.
+CVE-2023-28155

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,115 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+---
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+---
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+---
+
+## Security and Privacy
+
+Because Archivum Null is a privacy-focused project, the following additional expectations apply to all community members:
+
+- Do **not** attempt to access, intercept, or exfiltrate data belonging to other users of any running instance.
+- Do **not** probe, scan, or stress-test a running deployment you do not own or have explicit written permission to test.
+- Responsible disclosure of vulnerabilities must follow [SECURITY.md](SECURITY.md). Do **not** publish vulnerability details publicly before a fix has been released.
+- Do **not** share private keys, credentials, or secrets of other community members — even for "demonstration" purposes.
+
+Violating these rules is grounds for immediate and permanent removal from the community.
+
+---
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, open a [private security report on GitHub](https://github.com/whiteravens20/archivum-null/security/advisories/new) or contact the maintainers through the details in [SECURITY.md](SECURITY.md).
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+---
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1. **Warning**
+   - *Event:* A violation involving a single incident or series of incidents.
+   - *Consequence:* A private, written warning from the Community Moderators.
+   - *Repair:* Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+
+2. **Temporarily Limited Activities**
+   - *Event:* A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   - *Consequence:* A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   - *Repair:* Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+
+3. **Temporary Suspension**
+   - *Event:* A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   - *Consequence:* A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   - *Repair:* Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+
+4. **Permanent Ban**
+   - *Event:* A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member. Also applies to any violation of the [Security and Privacy](#security-and-privacy) rules above.
+   - *Consequence:* Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   - *Repair:* There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Moderators to use their discretion and judgment, in keeping with the best interests of our community.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all community spaces — GitHub issues, pull requests, discussions, the repository wiki — and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the [Organization for Ethical Source](https://ethicalsource.dev/) and licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+The Security and Privacy section was written specifically for this project.
+
+The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).
+
+For answers to common questions about Contributor Covenant, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing to Matrix Bots
+
+Thank you for considering a contribution. This repository hosts two small Matrix bots (`dmbot/` and `roombot/`) that route messages through an optional n8n workflow. Please read this guide before opening a pull request.
+
+---
+
+## Before You Start
+
+- Check the [open issues](../../issues) and [pull requests](../../pulls) to avoid duplicating work.
+- For larger changes (new commands, new auth method, schema changes to the n8n webhook payload), open an issue first to discuss the approach.
+- By contributing, you agree to the project [License](LICENSE) and [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Scope of Contributions
+
+In scope:
+
+- Bug fixes in the bots' message handling.
+- New `!command` handlers and corresponding documentation.
+- Hardening (input validation, whitelist enforcement, webhook timeout / retry behaviour).
+- Docker / docker-compose improvements.
+- Documentation, including the `docs/` guides.
+
+Out of scope (or coordinate first):
+
+- Switching the SDK away from `matrix-bot-sdk`.
+- Persisting plaintext messages or storing user data beyond the in-memory window.
+- Adding analytics, telemetry, or any phone-home behaviour.
+
+## Development Setup
+
+### Requirements
+
+- Node.js 22 or newer (`matrix-bot-sdk` crypto requires it).
+- Docker + Docker Compose (for the full local stack with n8n).
+- A test Matrix homeserver account for each bot, or shared test accounts.
+
+### Local start
+
+Each bot is an independent ESM package.
+
+```bash
+cd dmbot   # or roombot
+npm ci
+cp ../.env.example ../.env   # fill in credentials
+npm start
+```
+
+### Environment variables
+
+See `.env.example` at the repo root. **Never commit a populated `.env`.** Use unique credentials per bot, even in development.
+
+## Coding Guidelines
+
+### General
+
+- ES modules (`"type": "module"`). No CommonJS in new files.
+- Keep individual files small and focused; both bots already split `index.js`, `config/`, and `handlers/`.
+- No dead code. Delete what isn't used.
+
+### Commits
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add !summarize command to roombot
+fix(dmbot): reject DM rooms with > 2 members
+chore: bump matrix-bot-sdk to 0.9.0
+docs: clarify webhook payload schema
+build: update axios and add dependency overrides
+```
+
+Sign your commits (`git commit -S`). The `main` branch requires signed commits.
+
+### Dependencies
+
+- Pin minor versions in `package.json`; lockfiles must be committed.
+- Run `npm audit --omit=dev` before adding a new runtime dependency. Production audit level is `moderate`; dev is `high`.
+- If `matrix-bot-sdk` pulls in something deprecated, add an entry in `SECURITY.md` rather than silently overriding.
+
+## Testing
+
+The repo does not yet have a test suite. The `test.yml` workflow currently runs `npm ci` in each bot directory and is a no-op for tests until one is added. When you add tests:
+
+- Place them in `dmbot/test/` and `roombot/test/`.
+- Wire `npm test` in each bot's `package.json`.
+- Update `.github/workflows/test.yml` if additional steps are needed.
+
+For now, manual verification against a real homeserver is expected. Document what you exercised in the PR description.
+
+## Submitting Changes
+
+1. Fork or create a topic branch from `dev`.
+2. Make your changes following the guidelines above.
+3. Open a draft PR against `dev` with a clear description and (if relevant) screenshots / log excerpts.
+4. Mark the PR ready once CI is green.
+
+PRs to `main` should come only from `dev` and only via maintainer release branches.
+
+## Reporting Security Vulnerabilities
+
+Do not open a public issue. Use [private vulnerability reporting](../../security/advisories/new) on GitHub. See `SECURITY.md` for the disclosure policy and the running list of known transitive vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Matrix Bots
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Test](https://github.com/whiteravens20/matrix-bots/actions/workflows/test.yml/badge.svg?branch=dev)](https://github.com/whiteravens20/matrix-bots/actions/workflows/test.yml)
+[![CodeQL](https://github.com/whiteravens20/matrix-bots/actions/workflows/codeql.yml/badge.svg?branch=dev)](https://github.com/whiteravens20/matrix-bots/actions/workflows/codeql.yml)
+
 A collection of Matrix bots built with Node.js and the Matrix Bot SDK. This repository contains two specialized bots: a DM bot for private direct messages and a Room bot for group conversations, both with optional n8n workflow integration for AI-powered responses.
 
 ## Features
@@ -338,6 +342,14 @@ This allows you to:
                     └─────────────┘
 ```
 
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request, and follow the [Code of Conduct](CODE_OF_CONDUCT.md). Active development happens on the `dev` branch; `main` is protected and requires signed commits.
+
+## Security
+
+Do not report security vulnerabilities through public GitHub issues. Use [private vulnerability reporting](https://github.com/whiteravens20/matrix-bots/security/advisories/new) instead. See [SECURITY.md](SECURITY.md) for the full disclosure policy and the running list of known transitive vulnerabilities.
+
 ## License
 
-See LICENSE file for details.
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
# Standardization report — matrix-bots (2026-05-19)

Audit run by `wr-standardize` against the WR house standard (reference: `archivum-null`, templates: `infra-agents/templates/_common/`).

The branch model and Conventional Commits requirement are now in place. Nothing was auto-merged; this PR is a draft for review.

---

## ADDED

Files that did not exist in the target repo and were created. Most templates needed adaptation from the `backend/`/`frontend/` archivum-null layout to the `dmbot/`/`roombot/` matrix-bots layout — those are noted inline.

- `CONTRIBUTING.md` — written from scratch for matrix-bots (the archivum-null template is heavily crypto/zero-knowledge specific and would not have applied).
- `CODE_OF_CONDUCT.md` — copied verbatim from `templates/_common/CODE_OF_CONDUCT.md` (Contributor Covenant).
- `.editorconfig` — copied verbatim.
- `.github/CODEOWNERS` — adapted: default `* @pavlojs`, with per-directory rules for `/dmbot/`, `/roombot/`, `/docker-compose.yml`, `/.github/`, `SECURITY.md`, and `LICENSE`.
- `.github/FUNDING.yml` — `ko_fi: whiteravens20`.
- `.github/dependabot.yml` — adapted: github-actions, docker, plus npm ecosystems for `/dmbot` and `/roombot` (instead of `/backend` and `/frontend`). All grouped non-breaking, weekly Monday 08:00 UTC, target `dev`.
- `.github/release.yml` — release notes config (labels → grouped categories). Emoji removed per WR convention for written output.
- `.github/PULL_REQUEST_TEMPLATE.md` — adapted: matrix-bots-specific verification checklist (manual Matrix testing, webhook routing, whitelist/room enforcement) instead of archivum-null's vault/crypto checklist.
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`, links updated to `whiteravens20/matrix-bots`.
- `.github/ISSUE_TEMPLATE/bug_report.md` — adapted: bot/version/auth-method fields instead of vault/Turnstile fields.
- `.github/ISSUE_TEMPLATE/feature_request.md` — adapted: webhook/whitelist impact fields instead of zero-knowledge fields.
- `.github/CICD.md` — adapted: workflow table and branch-protection rules for the matrix-bots workflow set (test/codeql/security/release/audit/auto-merge/quarantine).
- `.github/workflows/test.yml` — scaffolded fresh: Node 22 matrix, runs `npm ci --ignore-scripts` and `npm test` (when defined) in both `dmbot/` and `roombot/`. Includes a `node --check` syntax sweep and a no-push Docker build validation per bot. **Tests do not exist yet** — see follow-ups below.
- `.github/workflows/codeql.yml` — adapted: language `javascript` (not `javascript-typescript`), installs deps for both bots.
- `.github/workflows/security.yml` — adapted: matrix over `[dmbot, roombot]` for `npm audit` (production-moderate, dev-high) and `npm audit signatures`; keeps `dependency-review-action` and `trivy-action` filesystem scan; dropped the Docker image scan (handled in `release.yml` per-bot instead).
- `.github/workflows/release.yml` — rewritten: builds both `matrix-bots-dmbot` and `matrix-bots-roombot` images to GHCR with provenance + SBOM, scans each with Trivy, publishes a single GitHub Release with both pull commands. Skips tarball generation (project is mostly a runtime, not a buildable source distribution).
- `.github/workflows/branch-protection-audit.yml` — adapted: required-check names changed to match this repo's workflows; missing-checks logged as `::warning::` rather than `::error::` to avoid noisy red until checks are wired into branch protection.
- `.github/workflows/dependabot-auto-merge.yml` — adapted: `check-regexp` updated to match the new workflow names.
- `.github/workflows/quarantine-label.yml` — adapted: package-json path filter changed from `backend|frontend` to `dmbot|roombot`. Emoji removed.

## MODIFIED

- `README.md`
  - Added badge row: License (MIT), Test workflow, CodeQL workflow.
  - Appended `## Contributing`, `## Security`, `## License` sections at the end of the file. The pre-existing "Security" mid-document bullet list was left in place — it describes runtime behaviour, not the disclosure policy.
- `.gitignore`
  - Rewritten to a normalized form that merges the existing project rules with the WR template baseline (env files, `node_modules/`, `coverage/`, OS/editor noise, `*.log`, `.cache/`) and keeps the project-specific entries (`bot.json`, `bot-*.json`, `*/data/`, `n8n/`).

## SKIPPED (existed and differs — review manually)

- **`SECURITY.md`** — exists with a custom "Known Vulnerabilities" log the maintainer wants to keep. The WR mirror under `templates/_common/SECURITY.md` is the archivum-null version. If you want to align the disclosure-policy boilerplate (reporting channels, response timelines, supported versions), merge the relevant sections manually but keep the "Known Vulnerabilities (matrix-bot-sdk transitive)" log intact.
- **`CHANGELOG.md`** — uses emoji section headings (`### 🔄`, `### 🔒`, etc.). Low priority. Consider switching to Keep-a-Changelog format on the next release rather than rewriting history now.
- **`LICENSE`** — already MIT, matches WR house standard for libraries/services. Not touched.

## Follow-ups (no commit — tracked here)

- **No test suite exists.** `npm test` in both `dmbot/` and `roombot/` is currently undefined. The `test.yml` workflow is wired to detect this and skip with a `::notice::` rather than fail; replace with real tests as soon as practical. A minimal smoke test that exercises the command parser would cover most of the surface.
- **No `.trivyignore`.** The Trivy filesystem scan will block any HIGH/CRITICAL finding. If the `matrix-bot-sdk` transitive vulnerabilities documented in `SECURITY.md` reappear in a Trivy scan, add their CVE IDs to `.trivyignore` with justification.
- **`dmbot/` and `roombot/` Dockerfiles** — referenced by `test.yml` (`docker-build` job) and `release.yml` but the audit did not verify they exist. If they live elsewhere (e.g., a single root Dockerfile) the workflow paths need adjusting.
- **CodeOwners review requirement** — branch protection now requires code-owner approval, but the maintainer is the only owner. PRs you author yourself cannot be self-approved under this rule; either accept this for the human-protection benefit or add a co-maintainer.
- **`required_status_checks` on main** — intentionally left null. Once the new workflows have run at least once on `dev`, promote `Test (dmbot, Node 22)`, `Test (roombot, Node 22)`, `Analyze (javascript)`, and the `npm audit (...)` jobs to required checks via Settings → Branches.

---

## GitHub settings — applied

The following were applied successfully (no permissions issues):

### Repo settings

| Setting | Before | After |
|---|---|---|
| `default_branch` | `main` | `dev` |
| `has_issues` | `true` | `true` (unchanged) |
| `has_projects` | `false` | `false` (unchanged) |
| `has_wiki` | `false` | `false` (unchanged) |
| `security_and_analysis.dependabot_security_updates` | `disabled` | `enabled` |
| Vulnerability alerts | n/a | enabled |

A new `dev` branch was created off `main` and pushed to origin first; only then was the default branch flipped.

### Main branch protection

| Setting | Before | After |
|---|---|---|
| `require_code_owner_reviews` | `false` | `true` |
| `required_approving_review_count` | `1` | `1` (unchanged) |
| `required_signatures` | `enabled` | `enabled` (unchanged) |
| `allow_force_pushes` | `false` | `false` (unchanged) |
| `allow_deletions` | `false` | `false` (unchanged) |
| `enforce_admins` | `false` | `false` (unchanged, matches archivum-null) |
| `required_status_checks` | none | none (deliberately deferred — see follow-ups) |

This now matches archivum-null's protection rule except for the required status-check contexts, which can only meaningfully be set after the new workflows have produced at least one successful run.

## GitHub settings — not applied

None. All settings the agent attempted to change went through.