### PR TITLE
fix: reject roombot invites and whitelist dmbot invites

### DIFF
--- a/dmbot/index.js
+++ b/dmbot/index.js
@@ -3,6 +3,7 @@ import { MatrixClient, SimpleFsStorageProvider, MatrixAuth } from "matrix-bot-sd
 import axios from "axios";
 import config from "./config/config.js";
 import { createMessageHandler } from "./lib/handler.js";
+import { createInviteHandler } from "./lib/invite-handler.js";
 
 // Initialize storage
 const storage = new SimpleFsStorageProvider(`./data/bot-storage.json`);
@@ -46,10 +47,8 @@ await client.start();
 const botUserId = await client.getUserId();
 console.log(`✅ DM Bot started: ${botUserId}`);
 
-// Ignoring invitations
-client.on("room.invite", async (roomId, event) => {
-  console.log(`Ignoring invitation to room ${roomId} from ${event.sender}`);
-});
+// Accept or reject invitations based on whitelist
+client.on("room.invite", createInviteHandler({ client, config }));
 
 // DM-only with whitelist
 client.on("room.message", createMessageHandler({ client, config, axios, botUserId }));

--- a/dmbot/lib/invite-handler.js
+++ b/dmbot/lib/invite-handler.js
@@ -1,0 +1,23 @@
+// Builds the room.invite handler. Dependencies are injected so the handler
+// can be unit-tested without a live Matrix client.
+export function createInviteHandler({ client, config }) {
+  return async (roomId, event) => {
+    const sender = event.sender;
+
+    if (config.bot.allowedUsers.includes(sender)) {
+      console.log(`Accepting DM invitation from whitelisted user ${sender} to room ${roomId}`);
+      try {
+        await client.joinRoom(roomId);
+      } catch (err) {
+        console.error(`Failed to join room ${roomId}: ${err.message}`);
+      }
+    } else {
+      console.log(`Rejecting invitation to room ${roomId} from non-whitelisted user ${sender}`);
+      try {
+        await client.leaveRoom(roomId);
+      } catch (err) {
+        console.error(`Failed to leave room ${roomId}: ${err.message}`);
+      }
+    }
+  };
+}

--- a/dmbot/tests/invite-handler.test.js
+++ b/dmbot/tests/invite-handler.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createInviteHandler } from '../lib/invite-handler.js';
+
+const ROOM = '!dm:hs';
+const ALICE = '@alice:hs';
+const BOB = '@bob:hs';
+
+function makeClient() {
+  return {
+    leaveRoom: vi.fn().mockResolvedValue(undefined),
+    joinRoom: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+function makeConfig(overrides = {}) {
+  return {
+    bot: {
+      allowedUsers: [ALICE],
+      ...overrides.bot
+    }
+  };
+}
+
+function inviteEvent(sender = ALICE) {
+  return { sender };
+}
+
+describe('dmbot invite handler', () => {
+  let client;
+
+  beforeEach(() => {
+    client = makeClient();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('joins a room when invited by a whitelisted user', async () => {
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(ALICE));
+
+    expect(client.joinRoom).toHaveBeenCalledOnce();
+    expect(client.joinRoom).toHaveBeenCalledWith(ROOM);
+    expect(client.leaveRoom).not.toHaveBeenCalled();
+  });
+
+  it('leaves a room when invited by a non-whitelisted user', async () => {
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(BOB));
+
+    expect(client.leaveRoom).toHaveBeenCalledOnce();
+    expect(client.leaveRoom).toHaveBeenCalledWith(ROOM);
+    expect(client.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when joining fails', async () => {
+    client.joinRoom.mockRejectedValue(new Error('network error'));
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(ALICE));
+
+    expect(client.joinRoom).toHaveBeenCalledWith(ROOM);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to join room'));
+  });
+
+  it('logs an error when leaving fails', async () => {
+    client.leaveRoom.mockRejectedValue(new Error('network error'));
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(BOB));
+
+    expect(client.leaveRoom).toHaveBeenCalledWith(ROOM);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to leave room'));
+  });
+
+  it('handles empty allowedUsers list by rejecting all invites', async () => {
+    const handler = createInviteHandler({ client, config: makeConfig({ bot: { allowedUsers: [] } }) });
+    await handler(ROOM, inviteEvent(ALICE));
+
+    expect(client.leaveRoom).toHaveBeenCalledWith(ROOM);
+    expect(client.joinRoom).not.toHaveBeenCalled();
+  });
+});

--- a/roombot/index.js
+++ b/roombot/index.js
@@ -3,6 +3,7 @@ import { MatrixClient, SimpleFsStorageProvider, MatrixAuth } from "matrix-bot-sd
 import axios from "axios";
 import config from "./config/config.js";
 import { createMessageHandler } from "./lib/handler.js";
+import { createInviteHandler } from "./lib/invite-handler.js";
 
 // Validate TARGET_ROOM_ID is set
 if (!config.bot.targetRoomId) {
@@ -51,10 +52,8 @@ await client.start();
 const botUserId = await client.getUserId();
 console.log(`✅ Room Bot started: ${botUserId} - Listening in room: ${config.bot.targetRoomId}`);
 
-// Ignore invitations
-client.on("room.invite", async (roomId, event) => {
-  console.log(`Ignoring invitation to room ${roomId} from ${event.sender}`);
-});
+// Reject invitations to non-target rooms
+client.on("room.invite", createInviteHandler({ client, config }));
 
 // Listen for messages in configured room only
 client.on("room.message", createMessageHandler({ client, config, axios, botUserId }));

--- a/roombot/lib/invite-handler.js
+++ b/roombot/lib/invite-handler.js
@@ -1,0 +1,17 @@
+// Builds the room.invite handler. Dependencies are injected so the handler
+// can be unit-tested without a live Matrix client.
+export function createInviteHandler({ client, config }) {
+  return async (roomId, event) => {
+    if (roomId === config.bot.targetRoomId) {
+      console.log(`Ignoring invitation to target room ${roomId} from ${event.sender}`);
+      return;
+    }
+
+    console.log(`Rejecting invitation to room ${roomId} from ${event.sender}`);
+    try {
+      await client.leaveRoom(roomId);
+    } catch (err) {
+      console.error(`Failed to leave room ${roomId}: ${err.message}`);
+    }
+  };
+}

--- a/roombot/tests/invite-handler.test.js
+++ b/roombot/tests/invite-handler.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createInviteHandler } from '../lib/invite-handler.js';
+
+const ROOM = '!room:hs';
+const TARGET_ROOM = '!target:hs';
+const ALICE = '@alice:hs';
+const BOB = '@bob:hs';
+
+function makeClient() {
+  return {
+    leaveRoom: vi.fn().mockResolvedValue(undefined),
+    joinRoom: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+function makeConfig(overrides = {}) {
+  return {
+    bot: {
+      targetRoomId: TARGET_ROOM,
+      ...overrides.bot
+    }
+  };
+}
+
+function inviteEvent(sender = ALICE) {
+  return { sender };
+}
+
+describe('roombot invite handler', () => {
+  let client;
+
+  beforeEach(() => {
+    client = makeClient();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('leaves an invited room that is not the target room', async () => {
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(ALICE));
+
+    expect(client.leaveRoom).toHaveBeenCalledOnce();
+    expect(client.leaveRoom).toHaveBeenCalledWith(ROOM);
+    expect(client.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it('ignores invitation to the target room', async () => {
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(TARGET_ROOM, inviteEvent(ALICE));
+
+    expect(client.leaveRoom).not.toHaveBeenCalled();
+    expect(client.joinRoom).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when leaving fails', async () => {
+    client.leaveRoom.mockRejectedValue(new Error('network error'));
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(ALICE));
+
+    expect(client.leaveRoom).toHaveBeenCalledWith(ROOM);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to leave room'));
+  });
+
+  it('works with different senders', async () => {
+    const handler = createInviteHandler({ client, config: makeConfig() });
+    await handler(ROOM, inviteEvent(BOB));
+
+    expect(client.leaveRoom).toHaveBeenCalledWith(ROOM);
+  });
+});


### PR DESCRIPTION
## What

Extracts invite handling from both bot entry points into testable `lib/invite-handler.js` modules and gives each bot the correct security posture:

- **roombot** now calls `client.leaveRoom(roomId)` for every invite except the configured `TARGET_ROOM_ID` (which is ignored). This stops the bot from accumulating unwanted room memberships.
- **dmbot** now inspects the inviter against `config.bot.allowedUsers`. Whitelisted senders trigger `client.joinRoom(roomId)`; everyone else is rejected with `client.leaveRoom(roomId)`. Previously both bots silently logged and stayed joined.

## Why

Issue #7 reported that roombot logs invitations but never leaves, leaking presence and letting anyone pull the bot into arbitrary rooms. The same stub handler existed in dmbot. Making the behaviour explicit and tested closes the gap.

## How to test

```bash
cd roombot && npm test
cd dmbot && npm test
```

- roombot: 30/30 passing (4 new invite-handler tests)
- dmbot: 31/31 passing (5 new invite-handler tests)

## Files changed

- `roombot/lib/invite-handler.js` (new)
- `roombot/tests/invite-handler.test.js` (new)
- `dmbot/lib/invite-handler.js` (new)
- `dmbot/tests/invite-handler.test.js` (new)
- `roombot/index.js` – wires `createInviteHandler`
- `dmbot/index.js` – wires `createInviteHandler`

Closes #7
